### PR TITLE
fix(flake): explicitly requires flake parts input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -33,8 +33,9 @@
         "type": "github"
       },
       "original": {
-        "id": "flake-parts",
-        "type": "indirect"
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
       }
     },
     "home-manager": {

--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,8 @@
 
     sops-nix.url = "github:Mic92/sops-nix";
     sops-nix.inputs.nixpkgs.follows = "nixpkgs";
+
+    flake-parts.url = "github:hercules-ci/flake-parts";
   };
 
   outputs = inputs @ {


### PR DESCRIPTION
Following up on https://github.com/ALT-F4-LLC/kickstart.nix/pull/97#issuecomment-2676933544, this flake contains the same issue described in https://github.com/ALT-F4-LLC/kickstart.nix/issues/96 . This PR resolves the equivalent issue for https://github.com/Sironheart/nix-config . 